### PR TITLE
BString settings must be reassigned to the context as their location …

### DIFF
--- a/haiku-usynergy.cpp
+++ b/haiku-usynergy.cpp
@@ -404,6 +404,9 @@ void uSynergyInputServerDevice::_UpdateSettings()
 		fMessageName = "Synergy";
 	}
 
+	fContext->m_messageName = fMessageName;
+	fContext->m_clientName = fClientName;
+
 	unload_driver_settings(handle);
 }
 


### PR DESCRIPTION
if you set the client_name in the config file to anything longer than the default (haiku), then random memory will be used as the client name. 
Also, this would happen when switching between barrier and synergy (m_messageName) except that they are coincidentally the same length.
Any assignment of BString in the context should do this.