### PR TITLE
Fix Super key not working

### DIFF
--- a/haiku-usynergy.cpp
+++ b/haiku-usynergy.cpp
@@ -692,8 +692,8 @@ void uSynergyInputServerDevice::KeyboardCallback(uint16_t scancode, uint16_t _mo
 
 			fModifiers = modifiers;
 
-			//if (EnqueueMessage(message) != B_OK)
-			//	delete message;
+			if (EnqueueMessage(message) != B_OK)
+				delete message;
 		}
 	}
 


### PR DESCRIPTION
I noticed that the <Super> key does not work. ie you cannot glue windows together or stack properly.
This works with this fix, but I don't know why this code wa originally commeted out in this 
[commit](https://github.com/unarix/synergy_haiku/commit/c5930eaf10c8a93f3641cbe6c55ee31b67bee0fe#diff-20715588e637a97a10439c5b5fc141bc39bb397c1d01a1ef567c198d99e6b2c5)

I have only tested with Windows 7 server and Haiku client.